### PR TITLE
optimize example box

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,3 +143,14 @@ body #body .custom-links-pagination .active
 	{ color: #ddd;}
 body #body ._CatalogViewFrame_catalog
 	{filter:invert(1);}
+
+body #body .problem-statement .test-example-line-even
+	{ background: #222 }
+body #body .test-example-line
+	{ transition: all 0.15s ease; }
+body #body .test-example-line[style="background-color: rgb(255, 253, 231);"]
+	{ color: #000; font-size: large; }
+
+/* Compatible with Codeforces Better(https://greasyfork.org/users/747162) plugins */
+body #body .translate-problem-statement
+	{ background-color: #1e1f21;}


### PR DESCRIPTION
Codeforces will highlight even line and hover line in white color, which makes the statement hard to read.

![old](https://github.com/Serpong/codeforces-Zenmode-chrome-extension/assets/11132880/e4944f3c-a36c-4481-ad7b-164d70c602af)

This commit is just adjust the color of font simply.

![new](https://github.com/Serpong/codeforces-Zenmode-chrome-extension/assets/11132880/6f3424ec-dbf8-4bf9-8785-f712dd15cacc)
